### PR TITLE
chore: Use new account State

### DIFF
--- a/pkg/lz/accounts.go
+++ b/pkg/lz/accounts.go
@@ -92,9 +92,9 @@ func listAccounts(ctx context.Context, svc *organizations.Client, parentID strin
 
 		for i, account := range page.Accounts {
 			if i == len(page.Accounts)-1 {
-				fmt.Fprintf(w, "%s└── %s (%s)\t |\t %s\t |\t %s\n", prefix, *account.Name, *account.Id, *account.Email, account.Status)
+				fmt.Fprintf(w, "%s└── %s (%s)\t |\t %s\t |\t %s\n", prefix, *account.Name, *account.Id, *account.Email, account.State)
 			} else {
-				fmt.Fprintf(w, "%s├── %s (%s)\t |\t %s\t |\t %s\n", prefix, *account.Name, *account.Id, *account.Email, account.Status)
+				fmt.Fprintf(w, "%s├── %s (%s)\t |\t %s\t |\t %s\n", prefix, *account.Name, *account.Id, *account.Email, account.State)
 			}
 		}
 	}

--- a/pkg/lz/landingzone.go
+++ b/pkg/lz/landingzone.go
@@ -87,7 +87,7 @@ func FindAccounts(ctx context.Context, cfg aws.Config, Id string, filter string)
 
 		// Construct TableWriter
 		tw := ptable.NewWriter()
-		tw.AppendHeader(ptable.Row{"ID", "Email", "Name", "OU", "Status"})
+		tw.AppendHeader(ptable.Row{"ID", "Email", "Name", "OU", "State"})
 
 		// Process each account in the page
 		for _, account := range output.Accounts {
@@ -169,7 +169,7 @@ func getAccountDetails(account types.Account, ou string) ptable.Row {
 	  aws.ToString(account.Name),
 	  account.Status)*/
 
-	return ptable.Row{aws.ToString(account.Id), aws.ToString(account.Email), aws.ToString(account.Name), ou, account.Status}
+	return ptable.Row{aws.ToString(account.Id), aws.ToString(account.Email), aws.ToString(account.Name), ou, account.State}
 }
 
 func getRootId(ctx context.Context, client *organizations.Client) (string, error) {


### PR DESCRIPTION
Use new Organizations account `State` instead of deprecated `Status` field: https://aws.amazon.com/blogs/mt/updates-to-account-status-information-in-aws-organizations/